### PR TITLE
Add volume sliders

### DIFF
--- a/Globals/Music.gd
+++ b/Globals/Music.gd
@@ -11,11 +11,19 @@ enum ButtonType {
 	TICTACTOE_BUTTON
 }
 
+onready var bgm_player = $BGMPlayer
 onready var se_player = $SEPlayer
 
 var title_button_click = preload("res://Assets/Audio/SE/click1.ogg")
 var twentyone_button_click = preload("res://Assets/Audio/SE/click2.ogg")
 var tictactoe_button_click = preload("res://Assets/Audio/SE/click3.ogg")
+
+# volumes are in decibels, use db2linear() to convert to a slider value
+var bgm_volume setget set_bgm_volume, get_bgm_volume
+var se_volume setget set_se_volume, get_se_volume
+
+# config file to persist settings
+var config = ConfigFile.new()
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
@@ -23,7 +31,45 @@ func _ready():
 	twentyone_button_click.loop = false
 	tictactoe_button_click.loop = false
 	
-	pass # Replace with function body.
+	# attempt to read from configfile
+	var err = config.load("user://config.cfg")
+	
+	if err != OK:
+		config.set_value("audio", "bgm_volume_db", 0)
+		config.set_value("audio", "se_volume_db", 0)
+		config.save("user://config.cfg")
+	
+	set_bgm_volume(config.get_value("audio", "bgm_volume_db"))
+	set_se_volume(config.get_value("audio", "se_volume_db"))
+
+func _exit_tree():
+	config.save("user://config.cfg")
+
+## Set bgm volume in decibels
+## if using a slider to modify the volume, convert linear to
+## decibels using linear2db()
+func set_bgm_volume(new_volume):
+	bgm_player.volume_db = new_volume
+	config.set_value("audio", "bgm_volume_db", new_volume)
+
+## Returns bgm volume in decibels
+## if using this value to set a slider's value,
+## first call db2linear() on the returned value
+func get_bgm_volume():
+	return bgm_player.volume_db
+
+## Set bgm volume in decibels
+## if using a slider to modify the volume, convert linear to
+## decibels using linear2db()
+func set_se_volume(new_volume):
+	se_player.volume_db = new_volume
+	config.set_value("audio", "se_volume_db", new_volume)
+
+## Returns bgm volume in decibels
+## if using this value to set a slider's value,
+## first call db2linear() on the returned value
+func get_se_volume():
+	return se_player.volume_db
 
 func play_button_click(button_type):
 	match button_type:

--- a/Globals/Music.gd
+++ b/Globals/Music.gd
@@ -5,84 +5,101 @@ extends Node
 ## 	scenes.
 class_name BGM_SE_Player
 
+## Type of button control, for choosing sound effects
 enum ButtonType {
 	TITLE_BUTTON,
 	TWENTYONE_BUTTON,
 	TICTACTOE_BUTTON
 }
 
-onready var bgm_player = $BGMPlayer
-onready var se_player = $SEPlayer
+# AudioStreamPlayers used to play BGM and SE
+onready var _bgm_player = $BGMPlayer
+onready var _se_player = $SEPlayer
 
-var title_button_click = preload("res://Assets/Audio/SE/click1.ogg")
-var twentyone_button_click = preload("res://Assets/Audio/SE/click2.ogg")
-var tictactoe_button_click = preload("res://Assets/Audio/SE/click3.ogg")
+# sound effect files
+var _title_button_click = preload("res://Assets/Audio/SE/click1.ogg")
+var _twentyone_button_click = preload("res://Assets/Audio/SE/click2.ogg")
+var _tictactoe_button_click = preload("res://Assets/Audio/SE/click3.ogg")
 
-# volumes are in decibels, use db2linear() to convert to a slider value
-var bgm_volume setget set_bgm_volume, get_bgm_volume
-var se_volume setget set_se_volume, get_se_volume
+## Volume of background music, in decibels
+## if using a linear control to set/get (ex. [Slider]), convert
+## the linear value to decibels with linear2db() or convert
+## the decibel value to a linear value with db2linear().
+var bgm_volume setget _set_bgm_volume, _get_bgm_volume
+
+## Volume of sound effects, in decibels
+## if using a linear control to set/get (ex. [Slider]), convert
+## the linear value to decibels with linear2db() or convert
+## the decibel value to a linear value with db2linear().
+var se_volume setget _set_se_volume, _get_se_volume
 
 # config file to persist settings
-var config = ConfigFile.new()
+var _config = ConfigFile.new()
 
-# Called when the node enters the scene tree for the first time.
 func _ready():
-	title_button_click.loop = false
-	twentyone_button_click.loop = false
-	tictactoe_button_click.loop = false
+	# sound effects shouldn't loop
+	_title_button_click.loop = false
+	_twentyone_button_click.loop = false
+	_tictactoe_button_click.loop = false
 	
 	# attempt to read from configfile
-	var err = config.load("user://config.cfg")
+	var err = _config.load("user://config.cfg")
 	
+	# if config file doesn't exist, init to default values
 	if err != OK:
-		config.set_value("audio", "bgm_volume_db", 0)
-		config.set_value("audio", "se_volume_db", 0)
-		config.save("user://config.cfg")
+		_config.set_value("audio", "bgm_volume_db", 0)
+		_config.set_value("audio", "se_volume_db", 0)
+		_config.save("user://config.cfg")
 	
-	set_bgm_volume(config.get_value("audio", "bgm_volume_db"))
-	set_se_volume(config.get_value("audio", "se_volume_db"))
+	# read values from config file
+	_set_bgm_volume(_config.get_value("audio", "bgm_volume_db"))
+	_set_se_volume(_config.get_value("audio", "se_volume_db"))
 
 func _exit_tree():
-	config.save("user://config.cfg")
+	# save the config file to disk
+	_config.save("user://config.cfg")
 
 ## Set bgm volume in decibels
 ## if using a slider to modify the volume, convert linear to
 ## decibels using linear2db()
-func set_bgm_volume(new_volume):
-	bgm_player.volume_db = new_volume
-	config.set_value("audio", "bgm_volume_db", new_volume)
+func _set_bgm_volume(new_volume):
+	_bgm_player.volume_db = new_volume
+	_config.set_value("audio", "bgm_volume_db", new_volume)
 
 ## Returns bgm volume in decibels
 ## if using this value to set a slider's value,
 ## first call db2linear() on the returned value
-func get_bgm_volume():
-	return bgm_player.volume_db
+func _get_bgm_volume():
+	return _bgm_player.volume_db
 
 ## Set bgm volume in decibels
 ## if using a slider to modify the volume, convert linear to
 ## decibels using linear2db()
-func set_se_volume(new_volume):
-	se_player.volume_db = new_volume
-	config.set_value("audio", "se_volume_db", new_volume)
+func _set_se_volume(new_volume):
+	_se_player.volume_db = new_volume
+	_config.set_value("audio", "se_volume_db", new_volume)
 
 ## Returns bgm volume in decibels
 ## if using this value to set a slider's value,
 ## first call db2linear() on the returned value
-func get_se_volume():
-	return se_player.volume_db
+func _get_se_volume():
+	return _se_player.volume_db
 
-func play_button_click(button_type):
+## Play a button click sound effect
+## Pass a value of ButtonType to play a certain sound effect,
+## or nothing to play a default sound.
+func play_button_click(button_type=null):
 	match button_type:
 		ButtonType.TITLE_BUTTON:
-			se_player.stream = title_button_click
-			se_player.play()
+			_se_player.stream = _title_button_click
+			_se_player.play()
 		ButtonType.TWENTYONE_BUTTON:
-			se_player.stream = twentyone_button_click
-			se_player.play()
+			_se_player.stream = _twentyone_button_click
+			_se_player.play()
 		ButtonType.TICTACTOE_BUTTON:
-			se_player.stream = tictactoe_button_click
-			se_player.play()
+			_se_player.stream = _tictactoe_button_click
+			_se_player.play()
 		_:
-			se_player.stream = title_button_click
-			se_player.play()
+			_se_player.stream = _title_button_click
+			_se_player.play()
 		

--- a/Globals/Music.gd
+++ b/Globals/Music.gd
@@ -6,11 +6,7 @@ extends Node
 class_name BGM_SE_Player
 
 ## Type of button control, for choosing sound effects
-enum ButtonType {
-	TITLE_BUTTON,
-	TWENTYONE_BUTTON,
-	TICTACTOE_BUTTON
-}
+enum ButtonType { TITLE_BUTTON, TWENTYONE_BUTTON, TICTACTOE_BUTTON }
 
 # AudioStreamPlayers used to play BGM and SE
 onready var _bgm_player = $BGMPlayer
@@ -36,28 +32,31 @@ var se_volume setget _set_se_volume, _get_se_volume
 # config file to persist settings
 var _config = ConfigFile.new()
 
+
 func _ready():
 	# sound effects shouldn't loop
 	_title_button_click.loop = false
 	_twentyone_button_click.loop = false
 	_tictactoe_button_click.loop = false
-	
+
 	# attempt to read from configfile
 	var err = _config.load("user://config.cfg")
-	
+
 	# if config file doesn't exist, init to default values
 	if err != OK:
 		_config.set_value("audio", "bgm_volume_db", 0)
 		_config.set_value("audio", "se_volume_db", 0)
 		_config.save("user://config.cfg")
-	
+
 	# read values from config file
 	_set_bgm_volume(_config.get_value("audio", "bgm_volume_db"))
 	_set_se_volume(_config.get_value("audio", "se_volume_db"))
 
+
 func _exit_tree():
 	# save the config file to disk
 	_config.save("user://config.cfg")
+
 
 ## Set bgm volume in decibels
 ## if using a slider to modify the volume, convert linear to
@@ -66,11 +65,13 @@ func _set_bgm_volume(new_volume):
 	_bgm_player.volume_db = new_volume
 	_config.set_value("audio", "bgm_volume_db", new_volume)
 
+
 ## Returns bgm volume in decibels
 ## if using this value to set a slider's value,
 ## first call db2linear() on the returned value
 func _get_bgm_volume():
 	return _bgm_player.volume_db
+
 
 ## Set bgm volume in decibels
 ## if using a slider to modify the volume, convert linear to
@@ -79,16 +80,18 @@ func _set_se_volume(new_volume):
 	_se_player.volume_db = new_volume
 	_config.set_value("audio", "se_volume_db", new_volume)
 
+
 ## Returns bgm volume in decibels
 ## if using this value to set a slider's value,
 ## first call db2linear() on the returned value
 func _get_se_volume():
 	return _se_player.volume_db
 
+
 ## Play a button click sound effect
 ## Pass a value of ButtonType to play a certain sound effect,
 ## or nothing to play a default sound.
-func play_button_click(button_type=null):
+func play_button_click(button_type = null):
 	match button_type:
 		ButtonType.TITLE_BUTTON:
 			_se_player.stream = _title_button_click
@@ -102,4 +105,3 @@ func play_button_click(button_type=null):
 		_:
 			_se_player.stream = _title_button_click
 			_se_player.play()
-		

--- a/Globals/Music.tscn
+++ b/Globals/Music.tscn
@@ -5,6 +5,6 @@
 [node name="Music" type="Node"]
 script = ExtResource( 1 )
 
-[node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
+[node name="BGMPlayer" type="AudioStreamPlayer" parent="."]
 
 [node name="SEPlayer" type="AudioStreamPlayer" parent="."]

--- a/Options/Options.gd
+++ b/Options/Options.gd
@@ -1,7 +1,23 @@
 extends Node
 
+onready var bgm_slider = $MarginContainer/VBoxContainer/OptionsContainer/BGMSlider
+onready var se_slider = $MarginContainer/VBoxContainer/OptionsContainer/SESlider
+
 func _ready():
-	pass
+	bgm_slider.value = db2linear(Music.bgm_volume)
+	se_slider.value = db2linear(Music.se_volume)
 
 func _on_Button_pressed():
 	Transit.change_scene("res://Title/Main.tscn")
+
+
+func _on_BGMSlider_value_changed(value):
+	Music.bgm_volume = linear2db(value)
+
+
+func _on_SESlider_value_changed(value):
+	Music.se_volume = linear2db(value)
+
+
+func _on_TestButton_pressed():
+	Music.play_button_click(Music.ButtonType.TITLE_BUTTON)

--- a/Options/Options.tscn
+++ b/Options/Options.tscn
@@ -1,8 +1,22 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://Assets/Images/options-menu-header.png" type="Texture" id=1]
 [ext_resource path="res://Assets/TitleTheme.tres" type="Theme" id=2]
+[ext_resource path="res://Assets/Fonts/OpenSans-VariableFont_wdth,wght.ttf" type="DynamicFontData" id=3]
 [ext_resource path="res://Options/Options.gd" type="Script" id=4]
+
+[sub_resource type="DynamicFont" id=1]
+size = 48
+font_data = ExtResource( 3 )
+
+[sub_resource type="ImageTexture" id=3]
+
+[sub_resource type="StyleBoxFlat" id=2]
+bg_color = Color( 0, 0, 0, 1 )
+border_width_top = 20
+border_width_bottom = 20
+
+[sub_resource type="ImageTexture" id=4]
 
 [node name="Node" type="Node"]
 script = ExtResource( 4 )
@@ -28,12 +42,78 @@ margin_bottom = 1720.0
 
 [node name="TextureRect" type="TextureRect" parent="MarginContainer/VBoxContainer"]
 margin_right = 980.0
-margin_bottom = 1620.0
-size_flags_horizontal = 3
+margin_bottom = 808.0
 size_flags_vertical = 3
 texture = ExtResource( 1 )
 expand = true
 stretch_mode = 5
+
+[node name="OptionsContainer" type="GridContainer" parent="MarginContainer/VBoxContainer"]
+margin_top = 812.0
+margin_right = 980.0
+margin_bottom = 1620.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+custom_constants/hseparation = 50
+columns = 2
+
+[node name="Volume" type="Label" parent="MarginContainer/VBoxContainer/OptionsContainer"]
+margin_right = 410.0
+margin_bottom = 99.0
+theme = ExtResource( 2 )
+text = "Volume"
+
+[node name="Spacer" type="Control" parent="MarginContainer/VBoxContainer/OptionsContainer"]
+margin_left = 460.0
+margin_right = 980.0
+margin_bottom = 99.0
+
+[node name="BGMLabel" type="Label" parent="MarginContainer/VBoxContainer/OptionsContainer"]
+margin_top = 103.0
+margin_right = 410.0
+margin_bottom = 170.0
+theme = ExtResource( 2 )
+custom_fonts/font = SubResource( 1 )
+text = "Background Music"
+
+[node name="BGMSlider" type="HSlider" parent="MarginContainer/VBoxContainer/OptionsContainer"]
+margin_left = 460.0
+margin_top = 103.0
+margin_right = 980.0
+margin_bottom = 170.0
+size_flags_horizontal = 3
+size_flags_vertical = 1
+custom_icons/grabber = SubResource( 3 )
+custom_styles/slider = SubResource( 2 )
+max_value = 1.0
+step = 0.01
+
+[node name="SELabel" type="Label" parent="MarginContainer/VBoxContainer/OptionsContainer"]
+margin_top = 174.0
+margin_right = 410.0
+margin_bottom = 241.0
+theme = ExtResource( 2 )
+custom_fonts/font = SubResource( 1 )
+text = "Sound Effects"
+
+[node name="SESlider" type="HSlider" parent="MarginContainer/VBoxContainer/OptionsContainer"]
+margin_left = 460.0
+margin_top = 174.0
+margin_right = 980.0
+margin_bottom = 241.0
+size_flags_horizontal = 3
+size_flags_vertical = 1
+custom_icons/grabber = SubResource( 4 )
+custom_styles/slider = SubResource( 2 )
+max_value = 1.0
+step = 0.01
+
+[node name="TestButton" type="Button" parent="MarginContainer/VBoxContainer/OptionsContainer"]
+margin_top = 245.0
+margin_right = 410.0
+margin_bottom = 350.0
+theme = ExtResource( 2 )
+text = "Test Button"
 
 [node name="Button" type="Button" parent="."]
 anchor_top = 1.0
@@ -45,4 +125,7 @@ margin_bottom = -54.0
 theme = ExtResource( 2 )
 text = "<- Back"
 
+[connection signal="value_changed" from="MarginContainer/VBoxContainer/OptionsContainer/BGMSlider" to="." method="_on_BGMSlider_value_changed"]
+[connection signal="value_changed" from="MarginContainer/VBoxContainer/OptionsContainer/SESlider" to="." method="_on_SESlider_value_changed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/OptionsContainer/TestButton" to="." method="_on_TestButton_pressed"]
 [connection signal="pressed" from="Button" to="." method="_on_Button_pressed"]

--- a/Player/PlayerCard.gd
+++ b/Player/PlayerCard.gd
@@ -1,7 +1,7 @@
 extends Node
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	self.connect("script_changed", $PlayerMarginContainer, "update_score")
+	var _temp = self.connect("script_changed", $PlayerMarginContainer, "update_score")
 	if Deck.new_round == true:
 		reset_deck()
 		for _i in range(2):


### PR DESCRIPTION
This PR closes #43 . I added sliders to change the Background Music and Sound Effect volumes separately, as well as a config file to persist the volumes across runs of our game. There currently isn't any music added to our game, but I tested the sound effect volume slider and it works as expected.